### PR TITLE
Add sourcemap to rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,7 @@ export default [
             resolve(),
             typescript({
                 noEmitOnError: false
-                sourcemap: false
+                sourceMap: false
             }),
             commonjs(),
             production && terser()

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,6 +24,7 @@ export default [
             }),
             commonjs(),
             production && terser()
-        ]
+        ],
+        sourcemap: true
     },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,17 +14,18 @@ export default [
         input: 'src/ts/main.ts',
         output: {
             file: 'dist/js/main.min.js',
-            format: 'iife'
+            format: 'iife',
+            sourcemap: true
         },
         plugins: [
             notify(),
             resolve(),
             typescript({
                 noEmitOnError: false
+                sourcemap: false
             }),
             commonjs(),
             production && terser()
         ],
-        sourcemap: true
     },
 ];


### PR DESCRIPTION
This fixes the error:
"(!) Plugin typescript: @rollup/plugin-typescript: Rollup 'sourcemap' option must be set to generate source maps."